### PR TITLE
More convenient key derivation operations

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bip47"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Straylight <https://github.com/straylight-orbit>"]
 license = "CC0-1.0"
 description = "BIP47 (Reusable Payment Codes) implementation"


### PR DESCRIPTION
There exist rare situations where it is necessary to perform manual blinding and unblinding operations outside the scope of notification transactons. That cannot be done unless notification private and public keys are directly derivable. It is now also possible to spend from the notification key, as well as from standard receive keys.